### PR TITLE
Don't force SSL on health check

### DIFF
--- a/app/controllers/health/health_controller.rb
+++ b/app/controllers/health/health_controller.rb
@@ -1,5 +1,7 @@
 module Health
   class HealthController < ActionController::Base
+    force_ssl except: :show
+    
     def show
       payload = {
         name: Rails.application.class.parent_name.underscore,


### PR DESCRIPTION
Most health checks don't use SSL and redirecting the request simply is marked as a fail.